### PR TITLE
feat: extend structured data with type WebApplication

### DIFF
--- a/src/structured-data/web-app.test.ts
+++ b/src/structured-data/web-app.test.ts
@@ -1,0 +1,63 @@
+import type { WebApplication } from "schema-dts"
+import { webApp } from "./web-app"
+
+describe("webApp", () => {
+	it("should return the correct structured data", () => {
+		const data: WebApplication = {
+			"@type": "WebApplication",
+			name: "Example Web App",
+			url: "https://example.com",
+			browserRequirements: "Chrome 90+, Firefox 88+",
+			offers: {
+				"@type": "Offer",
+				price: "0.00",
+				priceCurrency: "USD",
+			},
+		}
+
+		expect(webApp(data)).toEqual({
+			"@context": "https://schema.org",
+			...data,
+		})
+	})
+
+	it("should return the correct structured data with an image", () => {
+		const data: WebApplication = {
+			"@type": "WebApplication",
+			name: "Example Web App",
+			url: "https://example.com",
+			browserRequirements: "Chrome 90+, Firefox 88+",
+			offers: {
+				"@type": "Offer",
+				price: "0.00",
+				priceCurrency: "USD",
+			},
+			image: "https://example.com/example-app.jpg",
+		}
+
+		expect(webApp(data)).toEqual({
+			"@context": "https://schema.org",
+			...data,
+		})
+	})
+
+	it("should return the correct structured data with a description", () => {
+		const data: WebApplication = {
+			"@type": "WebApplication",
+			name: "Example Web App",
+			url: "https://example.com",
+			browserRequirements: "Chrome 90+, Firefox 88+",
+			offers: {
+				"@type": "Offer",
+				price: "0.00",
+				priceCurrency: "USD",
+			},
+			description: "An example web application description.",
+		}
+
+		expect(webApp(data)).toEqual({
+			"@context": "https://schema.org",
+			...data,
+		})
+	})
+})

--- a/src/structured-data/web-app.ts
+++ b/src/structured-data/web-app.ts
@@ -1,0 +1,16 @@
+import type { WebApplication, WithContext } from "schema-dts"
+
+/**
+ *  This helper is used to generate a WebApplication ld+json structured data object.
+ * @param webApp  WebApplication object
+ * @see https://schema.org/WebApplication
+ * @returns Returns a WebApplication object to be used in head via json-ld script tag
+ */
+export const webApp = (webApp: WebApplication): WithContext<WebApplication> => {
+	return {
+		"@context": "https://schema.org",
+		...webApp,
+	}
+}
+
+export type { WebApplication }


### PR DESCRIPTION
As requested on Discord, hereby an additional JSON-LD type for WebApplications.

The tests match your SoftwareApplication approach but use properties relevant for the WebApplication type.