### PR TITLE
fix: remove non-existent packages from optionalDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,14 +47,13 @@
 	},
 	"optionalDependencies": {
 		"@remix-run/server-runtime": ">=2",
-		"@rollup/rollup-darwin-x64-gnu": "^4.18.1",
-		"@rollup/rollup-darwin-x64-musl": "^4.18.1",
+		"@rollup/rollup-darwin-x64": "^4.18.1",
+		"@rollup/rollup-darwin-arm64": "^4.18.1",
 		"@rollup/rollup-linux-arm64-gnu": "4.18.1",
 		"@rollup/rollup-linux-x64-gnu": "^4.18.1",
 		"@rollup/rollup-linux-x64-musl": "^4.18.1",
 		"@rollup/rollup-win32-arm64-msvc": "4.18.1",
-		"@rollup/rollup-win32-x64-msvc": "4.18.1",
-		"@rollup/rollup-win32-x64-musl": "4.18.1"
+		"@rollup/rollup-win32-x64-msvc": "4.18.1"
 	},
 	"dependencies": {
 		"url-pattern": "^1.0.3"


### PR DESCRIPTION
**Fixes #14 **

# Description

This PR removes `optionalDependencies` entries that pointed to non-existent npm packages.
These dependencies caused installation errors (e.g., in BunJS) due to incorrect `package.json` configuration.

The motivation for this change is to ensure that the installation process works consistently across environments and does not fail when attempting to fetch unavailable packages.

## Type of change

Please mark relevant options with an `x` in the brackets.

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ] This change requires a documentation update
* [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
* [ ] Other (please describe):

# How Has This Been Tested?

Manual tests were performed by:

1. Installing the project dependencies after removing invalid optional dependencies.
2. Verifying that the installation no longer fails on BunJS and npm.

* [ ] Integration tests
* [ ] Unit tests
* [x] Manual tests
* [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

* [ ] Check if the UI is working as expected and is satisfactory
* [ ] Check if the code is well documented
* [x] Check if the behavior is what is expected
* [ ] Check if the code is well tested
* [x] Check if the code is readable and well formatted
* [ ] Additional checks (document below if any)