### PR TITLE
feat(sitemap): support root-level sitemap fallback for dynamic routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -357,6 +357,8 @@ export const handle: SitemapHandle<SitemapData> = {
 }
 ```
 
+This applies to all routes, including `root.tsx`. The `root.tsx` sitemap function acts as a fallback and will run for any route that does not define its own sitemap handle.
+
 ### Handling sitemap index + dynamic sitemaps + robots.txt
 
 If you want to generate different sitemaps based on the language you can use the following approach:

--- a/src/remix/sitemap.ts
+++ b/src/remix/sitemap.ts
@@ -42,6 +42,11 @@ const createExtendedRoutes = (routes: RouteManifest<InternalServerRoute | undefi
 		}
 	})
 }
+
+const hasSitemapHandle = (handle: unknown): handle is { sitemap: SitemapFunction<unknown> } => {
+	return Boolean(handle && typeof handle === "object" && "sitemap" in handle && typeof handle.sitemap === "function")
+}
+
 const generateRemixSitemapRoutes = async ({
 	domain,
 	sitemapData,
@@ -54,21 +59,32 @@ const generateRemixSitemapRoutes = async ({
 	// Add the url to each route
 	const extendedRoutes = createExtendedRoutes(routes)
 
+	const rootRoute = extendedRoutes.find(({ id }) => id === "root")
+	const rootHandle = rootRoute?.module?.handle
+
+	const hasRootHandle = hasSitemapHandle(rootHandle)
+
 	const transformedRoutes = await Promise.all(
 		extendedRoutes.map(async (route) => {
-			const url = route.url
 			// We don't want to include the root route in the sitemap
 			if (route.id === "root") return
-			// If the route has a module, get the handle
+
+			const url = route.url
 			const handle = route.module?.handle
-			// If the route has a sitemap function, call it and return the sitemap entries
-			if (handle && typeof handle === "object" && "sitemap" in handle && typeof handle.sitemap === "function") {
-				// Type the function just in case
-				const sitemap = handle.sitemap as SitemapFunction<unknown>
-				const sitemapEntries: SitemapFunctionReturnData = await sitemap(domain, url, sitemapData)
+
+			// Run the route sitemap function if it exists
+			if (hasSitemapHandle(handle)) {
+				const sitemapEntries = await handle.sitemap(domain, url, sitemapData)
 				return { url, sitemapEntries, id: route.id }
 			}
-			// Otherwise, just return the route as a single entry
+
+			// As a fallback run the root route sitemap function
+			if (hasRootHandle) {
+				const sitemapEntries = await rootHandle.sitemap(domain, url, sitemapData)
+				return { url, sitemapEntries, id: route.id }
+			}
+
+			// If no sitemap function was found, just return the route as a single entry
 			return { url, sitemapEntries: null, id: route.id }
 		})
 	)


### PR DESCRIPTION
Fixes #18

# Description
This PR enhances the Remix/React Router v7 sitemap generation by introducing a **root handle fallback**.

Previously, only route-level `handle.sitemap` functions were supported. Now:
- If a route defines a `handle.sitemap`, it will run for that route.
- If a route does **not** define a sitemap handle, the `root.tsx` sitemap function will run as a fallback if it exists.

This ensures consistent sitemap generation across all routes and reduces duplication for shared logic like multilingual alternates.

## Type of change

Please mark relevant options with an `x` in the brackets.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?
This was tested locally directly on a React Router v7 project that I'm currently working on. I defined a `handle` function that returned a object with a `sitemap` function on my `root.tsx` and then checked the sitemap generated.

- [ ] Integration tests
- [ ] Unit tests
- [x] Manual tests
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [x] Check if the UI is working as expected and is satisfactory
- [x] Check if the code is well documented
- [x] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [x] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)

# Screenshots (if appropriate):

# Questions (if appropriate):
