### PR TITLE
fix(sitemap): remove layout routes from the sitemap list

### DIFF
--- a/src/remix/sitemap.ts
+++ b/src/remix/sitemap.ts
@@ -35,12 +35,17 @@ const convertRemixPathToUrl = (routes: RouteManifest<Route | undefined>, route: 
 }
 
 const createExtendedRoutes = (routes: RouteManifest<InternalServerRoute | undefined>) => {
-	return Object.values(routes).map((route) => {
-		return {
-			...route,
-			url: convertRemixPathToUrl(routes, route),
-		}
-	})
+	return Object.values(routes)
+		.filter((route) => {
+			// Filter out layouts from the routes
+			return route?.path !== undefined || route?.index
+		})
+		.map((route) => {
+			return {
+				...route,
+				url: convertRemixPathToUrl(routes, route),
+			}
+		})
 }
 const generateRemixSitemapRoutes = async ({
 	domain,


### PR DESCRIPTION
Fixes #12

# Description

This PR fixes an issue where some routes were being duplicated in the sitemap for Remix/React Router v7.
This was being cause by layout routes were being treated as normal routes which they shouldn't be since they don't have any path associated to them that the user can navigate to.

The changes include:
- Filtering layout routes by checking if they the path is not `undefined ` or if the index is set to `true`.

## Type of change

Please mark relevant options with an `x` in the brackets.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

This was tested locally directly on a React Router v7 project that I'm currently working on. I defined layout for the home route which cased the home route to appear twice on the sitemap. After the changes it only appear once.

- [ ] Integration tests
- [ ] Unit tests
- [x] Manual tests
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the UI is working as expected and is satisfactory
- [x] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [x] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)

# Screenshots (if appropriate):

# Questions (if appropriate):
